### PR TITLE
Update Gemini model names to gemini-2.0-flash

### DIFF
--- a/agents/category_router.py
+++ b/agents/category_router.py
@@ -21,7 +21,7 @@ class CategoryRouter:
     
     def __init__(self):
         genai.configure(api_key=config.GEMINI_API_KEY)
-        self.model = genai.GenerativeModel('gemini-1.5-flash')
+        self.model = genai.GenerativeModel('gemini-2.0-flash')
         
         # מילות מפתח לזיהוי מהיר (fallback)
         self.keyword_hints = {

--- a/agents/parameter_validator.py
+++ b/agents/parameter_validator.py
@@ -164,7 +164,7 @@ class ParameterValidator:
     
     def __init__(self):
         genai.configure(api_key=config.GEMINI_API_KEY)
-        self.model = genai.GenerativeModel('gemini-1.5-flash')
+        self.model = genai.GenerativeModel('gemini-2.0-flash')
     
     async def validate(
         self, 

--- a/agents/refiner.py
+++ b/agents/refiner.py
@@ -26,7 +26,7 @@ class PromptRefiner:
     def __init__(self):
         genai.configure(api_key=config.GEMINI_API_KEY)
         # מודל איכותי יותר לשיפור
-        self.model = genai.GenerativeModel('gemini-1.5-pro')
+        self.model = genai.GenerativeModel('gemini-2.0-flash')
     
     async def refine(
         self,

--- a/agents/shadow_critic.py
+++ b/agents/shadow_critic.py
@@ -21,7 +21,7 @@ class ShadowCritic:
     
     def __init__(self):
         genai.configure(api_key=config.GEMINI_API_KEY)
-        self.model = genai.GenerativeModel('gemini-1.5-flash')
+        self.model = genai.GenerativeModel('gemini-2.0-flash')
         
     async def critique(
         self, 


### PR DESCRIPTION
The old model names (gemini-1.5-flash, gemini-1.5-pro) are no longer available in the API. Updated all agents to use gemini-2.0-flash.

https://claude.ai/code/session_019hvQ1ZRgQehgzU1WPxpxAw